### PR TITLE
chore: support node <14 with or operator

### DIFF
--- a/src/browser-driver-manager.js
+++ b/src/browser-driver-manager.js
@@ -38,7 +38,7 @@ async function browserDriverManager(userArgs) {
     }
 
     if (chromedriver) {
-      let version = chromedriver.split('=')[1] ?? 'stable';
+      let version = chromedriver.split('=')[1] || 'stable';
 
       if (['stable', 'beta', 'dev', 'canary'].includes(version)) {
         const channel = version;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator Nullish coalescing is node 14 + only and to support <14 just switched it to or operator